### PR TITLE
Fix NuGet.CommandLine version path.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>4.5.0</VersionPrefix>
+    <VersionPrefix>4.5.1</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,8 @@
 # Version History
 
+### 4.5.1
+* Fix NuGet.CommandLine version path.
+
 ### 4.5.0
 
 * Add `MSBuildSettings.MSBuildPath`.

--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -424,7 +424,7 @@ namespace Faithlife.Build
 
 			string? getPlatformArg()
 			{
-				var platformValue = platformOption.Value ?? settings?.SolutionPlatform;
+				var platformValue = platformOption?.Value ?? settings?.SolutionPlatform;
 				return platformValue == null ? null : $"-p:Platform={platformValue}";
 			}
 

--- a/src/Faithlife.Build/DotNetTools.cs
+++ b/src/Faithlife.Build/DotNetTools.cs
@@ -21,7 +21,7 @@ namespace Faithlife.Build
 		{
 			m_directory = Path.GetFullPath(directory);
 			m_sources = new List<string>();
-			m_nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages", "nuget.commandline", "5.1.0", "tools", "NuGet.exe");
+			m_nugetPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages", "nuget.commandline", "5.4.0", "tools", "NuGet.exe");
 		}
 
 		/// <summary>


### PR DESCRIPTION
I'm really enjoying using Faithlife.Build so far, but I just ran into this snag. It was very easy to work around, so I'm personally not too concerned about setting up a more general solution right now.

For reference, here's the version that's currently being installed:
https://github.com/Faithlife/FaithlifeBuild/blob/c8c96cae0dacd689f08fb1a6f0e086580ff8a2f4/src/Faithlife.Build/Faithlife.Build.csproj#L16