### PR TITLE
Update LibGit2Sharp to 0.27.0-preview-0100.

### DIFF
--- a/src/Faithlife.Build/Faithlife.Build.csproj
+++ b/src/Faithlife.Build/Faithlife.Build.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="3.7.0" />
     <PackageReference Include="Glob" Version="1.1.8" />
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0100" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="NuGet.CommandLine" Version="5.8.0" />
     <PackageReference Include="NuGet.Configuration" Version="5.8.0" />


### PR DESCRIPTION
Includes a fix libgit2/libgit2sharp#1884 for `AccessViolationException` on .NET SDK 5.0.7.