### PR TITLE
Create tags via GitHub API

### DIFF
--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -727,6 +727,7 @@ public static class DotNetBuild
 				HttpResponseMessage? response = null;
 				try
 				{
+					Console.WriteLine($"Pushing git tag {tagToPush} at {commitSha} (using GitHub API).");
 					var request = new HttpRequestMessage(HttpMethod.Post, apiUrl)
 					{
 						Content = new StringContent($"{{\"ref\":\"refs/tags/{tagToPush}\",\"sha\":\"{commitSha}\"}}", Encoding.UTF8, "application/json"),
@@ -785,7 +786,7 @@ public static class DotNetBuild
 			using var repository = OpenRepository(tagsRepoDirectory);
 			foreach (var tagToPush in tagsToPush)
 			{
-				Console.WriteLine($"Pushing git tag {tagToPush} at {commitSha}.");
+				Console.WriteLine($"Pushing git tag {tagToPush} at {commitSha} (using LibGit2Sharp).");
 				repository.ApplyTag(tagName: tagToPush, objectish: commitSha);
 				try
 				{


### PR DESCRIPTION
This should be faster and less error-prone than cloning the repo and pushing via libgit2sharp.

It makes use of several environment variables that are provided automatically to GitHub Actions: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables, as well as `GITHUB_TOKEN` for authentication: https://docs.github.com/en/actions/security-guides/automatic-token-authentication.