### PR TITLE
Add publish-nuget-output. #47

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,11 @@
 name: Build
 on:
   workflow_dispatch:
+    inputs:
+      beta-version-number:
+        description: 'Set when publishing a beta release. You must also use the workflow version from your branch.'
+        type: string
+        required: false
   push:
     paths-ignore:
     - '*.md'
@@ -38,9 +43,15 @@ jobs:
       run: .\build.ps1 build --skip restore
     - name: Test
       run: .\build.ps1 test --skip build
-    - name: Publish
+    - name: Publish (Stable)
       if: runner.os == 'Windows' && github.repository_owner == 'Faithlife' && github.ref == 'refs/heads/master'
       env:
         BUILD_BOT_PASSWORD: ${{ secrets.BUILD_BOT_PASSWORD }}
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: .\build.ps1 publish --skip test
+    - name: Publish (Beta)
+      if: runner.os == 'Windows' && github.repository_owner == 'Faithlife' && github.ref != 'refs/heads/master' && github.event.inputs.beta-version-number != ''
+      env:
+        BUILD_BOT_PASSWORD: ${{ secrets.BUILD_BOT_PASSWORD }}
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: .\build.ps1 publish --skip test --version-suffix beta.${{ github.event.inputs.beta-version-number }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>5.16.1</VersionPrefix>
+    <VersionPrefix>5.17.0</VersionPrefix>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## 5.17.0
 
 * Add `publish-nuget-output` target.
+* Always use `--skip-duplicates` when pushing to NuGet.
 
 ## 5.16.1
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 5.17.0
+
+* Add `publish-nuget-output` target.
+
 ## 5.16.1
 
 * Fix syntax error in verbosity parameter passed to `dotnet`.

--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -262,7 +262,6 @@ public static class DotNetBuild
 			var publishTrigger = triggerParts.Length >= 2 && triggerParts[0] == "publish" ? triggerParts[1] : null;
 			var shouldPublishPackages = publishTrigger == "package" || publishTrigger == "packages" || publishTrigger == "all";
 			var shouldPublishDocs = canPublishDocs && (publishTrigger == "docs" || publishTrigger == "all");
-			var shouldSkipDuplicates = publishTrigger == "all";
 
 			var triggerVersion = GetVersionFromTrigger(trigger);
 			if (triggerVersion is not null)
@@ -550,7 +549,7 @@ public static class DotNetBuild
 							"nuget", "push", packagePath,
 							"--source", nugetSource,
 							"--api-key", nugetApiKey,
-							shouldSkipDuplicates ? "--skip-duplicate" : null,
+							"--skip-duplicate",
 						};
 
 						var skippedDuplicate = false;


### PR DESCRIPTION
Implements #47

**Problem**
The current publish target assumes some build intermediates (obj directory) when determining information about what to publish. This is a problem for parallelized or distributed workflows that aggregate NuGet artifacts in a final publishing step, where there aren't any other build intermediates.

**Idea**
Add a new target, publish-nuget-output, which runs all the same publish logic without requiring build intermediates. This is a dedicated target as to avoid ambiguous behavior and requirements if trying to accomplish this using the existing publish step, but will still ensure proper tagging and documentation updates are made.