### PR TITLE
Enable auditing for package vulnerabilities

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,9 @@
     <EnableStrictModeForCompatibleFrameworksInPackageValidation>true</EnableStrictModeForCompatibleFrameworksInPackageValidation>
     <EnableStrictModeForCompatibleTfms>true</EnableStrictModeForCompatibleTfms>
     <DisablePackageBaselineValidation Condition=" $(PackageValidationBaselineVersion) == $(VersionPrefix) or $(PackageValidationBaselineVersion) == '0.0.0' ">true</DisablePackageBaselineValidation>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildNumber)' != '' ">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,11 +9,13 @@
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="NuGet.CommandLine" Version="6.6.2" />
-    <PackageVersion Include="NuGet.Configuration" Version="6.6.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.6.1" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.10.1" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.10.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
     <PackageVersion Include="NUnit" Version="4.1.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="Polly" Version="7.2.4" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="XmlDocMarkdown.Core" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Faithlife.Build/DotNetClassicTool.cs
+++ b/src/Faithlife.Build/DotNetClassicTool.cs
@@ -72,7 +72,7 @@ public sealed class DotNetClassicTool
 
 		var bestMatch = VersionRange.Parse(packageVersion).FindBestMatch(packageDirectories) ??
 			throw new BuildException($"Found restored NuGet package folder but no version is a best match: {packageFullPath}");
-		var packageBestMatchPath = Path.Combine(packagesPath, packageName.ToLowerInvariant(), bestMatch.OriginalVersion);
+		var packageBestMatchPath = Path.Combine(packagesPath, packageName.ToLowerInvariant(), bestMatch.OriginalVersion ?? bestMatch.ToString());
 
 		if (!Directory.Exists(packageBestMatchPath))
 			throw new BuildException($"Missing restored NuGet package that was a best match: {packageBestMatchPath}");

--- a/src/Faithlife.Build/Faithlife.Build.csproj
+++ b/src/Faithlife.Build/Faithlife.Build.csproj
@@ -16,8 +16,10 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="NuGet.CommandLine" />
     <PackageReference Include="NuGet.Configuration" />
+    <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="Polly" />
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Build/Build.csproj
+++ b/tools/Build/Build.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Faithlife.Build" VersionOverride="5.*" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This will make it more difficult to ship a Faithlife.Build package that has transitive dependencies on vulnerable packages, which improves the experience for consumers.

The changes to Build.csproj are temporary until an updated package can be published.