### PR TITLE
Allow additional environment variables to be set when running an app

### DIFF
--- a/src/Faithlife.Build/AppRunner.cs
+++ b/src/Faithlife.Build/AppRunner.cs
@@ -127,18 +127,27 @@ public static class AppRunner
 		var handleOutputLine = settings.HandleOutputLine;
 		var handleErrorLine = settings.HandleErrorLine;
 
+		var startInfo = new ProcessStartInfo
+		{
+			FileName = commandPath,
+			Arguments = argsString,
+			WorkingDirectory = settings.WorkingDirectory,
+			UseShellExecute = false,
+			RedirectStandardOutput = handleOutputLine is not null,
+			RedirectStandardError = handleErrorLine is not null,
+			CreateNoWindow = false,
+		};
+
+		// add environment variables only if they're specified (to avoid touching the lazy ProcessStartInfo.Environment property)
+		if (settings.EnvironmentVariables.Count != 0)
+		{
+			foreach (var (name, value) in settings.EnvironmentVariables)
+				startInfo.Environment.Add(name, value);
+		}
+
 		using var process = new Process
 		{
-			StartInfo = new ProcessStartInfo
-			{
-				FileName = commandPath,
-				Arguments = argsString,
-				WorkingDirectory = settings.WorkingDirectory,
-				UseShellExecute = false,
-				RedirectStandardOutput = handleOutputLine is not null,
-				RedirectStandardError = handleErrorLine is not null,
-				CreateNoWindow = false,
-			},
+			StartInfo = startInfo,
 		};
 
 		if (!settings.NoEcho)

--- a/src/Faithlife.Build/AppRunnerSettings.cs
+++ b/src/Faithlife.Build/AppRunnerSettings.cs
@@ -16,6 +16,11 @@ public sealed class AppRunnerSettings
 	public string? WorkingDirectory { get; set; }
 
 	/// <summary>
+	/// Additional environment variables to set when running the app.
+	/// </summary>
+	public IDictionary<string, string?> EnvironmentVariables { get; private set; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>
 	/// True if the process information should not be written to standard error.
 	/// </summary>
 	public bool NoEcho { get; set; }
@@ -52,6 +57,7 @@ public sealed class AppRunnerSettings
 	{
 		var clone = (AppRunnerSettings) MemberwiseClone();
 		clone.Arguments = clone.Arguments?.ToList();
+		clone.EnvironmentVariables = new Dictionary<string, string?>(clone.EnvironmentVariables, StringComparer.OrdinalIgnoreCase);
 		return clone;
 	}
 }


### PR DESCRIPTION
This is typed as a non-null get-only property so users can use collection initialization syntax:

```csharp
new AppRunnerSettings
{
	EnvironmentVariables =
	{
		{ "name", "value" },
	},
}
```