### PR TITLE
Add support for signing NuGet packages before publishing

### DIFF
--- a/src/Faithlife.Build/AzureKeyVaultSigningSettings.cs
+++ b/src/Faithlife.Build/AzureKeyVaultSigningSettings.cs
@@ -1,0 +1,17 @@
+namespace Faithlife.Build;
+
+/// <summary>
+/// Settings for signing packages using Azure Key Vault.
+/// </summary>
+public sealed class AzureKeyVaultSigningSettings
+{
+	/// <summary>
+	/// The Azure Key Vault URL.
+	/// </summary>
+	public Uri? KeyVaultUrl { get; set; }
+
+	/// <summary>
+	/// The Azure Key Vault certificate name.
+	/// </summary>
+	public string? CertificateName { get; set; }
+}

--- a/src/Faithlife.Build/DotNetPackageSettings.cs
+++ b/src/Faithlife.Build/DotNetPackageSettings.cs
@@ -6,6 +6,11 @@ namespace Faithlife.Build;
 public sealed class DotNetPackageSettings
 {
 	/// <summary>
+	/// Settings for signing NuGet packages.
+	/// </summary>
+	public DotNetSigningSettings? SigningSettings { get; set; }
+
+	/// <summary>
 	/// Called to find the projects to package.
 	/// </summary>
 	public Func<IReadOnlyList<string>>? FindProjects { get; set; }

--- a/src/Faithlife.Build/DotNetSigningSettings.cs
+++ b/src/Faithlife.Build/DotNetSigningSettings.cs
@@ -1,0 +1,18 @@
+namespace Faithlife.Build;
+
+/// <summary>
+/// Settings for signing NuGet packages.
+/// </summary>
+/// <remarks>Only one of <see cref="TrustedSigningSettings"/> or <see cref="AzureKeyVaultSettings"/> must to specify the certificate to use for signing.</remarks>
+public sealed class DotNetSigningSettings
+{
+	/// <summary>
+	/// Settings for signing packages using Azure Trusted Signing.
+	/// </summary>
+	public TrustedSigningSettings? TrustedSigningSettings { get; set; }
+
+	/// <summary>
+	/// Settings for signing packages using a certificate stored in Azure Key Vault.
+	/// </summary>
+	public AzureKeyVaultSigningSettings? AzureKeyVaultSettings { get; set; }
+}

--- a/src/Faithlife.Build/TrustedSigningSettings.cs
+++ b/src/Faithlife.Build/TrustedSigningSettings.cs
@@ -1,0 +1,23 @@
+namespace Faithlife.Build;
+
+/// <summary>
+/// Settings for signing packages using Azure Trusted Signing.
+/// </summary>
+/// <remarks>For more information, see <a href="https://learn.microsoft.com/en-us/azure/trusted-signing/overview">What is Trusted Signing?</a></remarks>
+public sealed class TrustedSigningSettings
+{
+	/// <summary>
+	/// The Trusted Signing Account endpoint. The value must be a URI that aligns to the region that your Trusted Signing Account and Certificate Profile were created in.
+	/// </summary>
+	public Uri? EndpointUrl { get; set; }
+
+	/// <summary>
+	/// The Trusted Signing Account name.
+	/// </summary>
+	public string? Account { get; set; }
+
+	/// <summary>
+	/// The Certificate Profile name.
+	/// </summary>
+	public string? CertificateProfile { get; set; }
+}


### PR DESCRIPTION
Both Azure Key Vault and Azure Trusted Signing are supported as certificate sources, using 'dotnet sign' for the signing implementation.