### PR TITLE
Enforce CI properties via Directory.Build.targets temp file

### DIFF
--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -1127,9 +1127,9 @@ public static class DotNetBuild
 			return new(tempPath);
 		}
 
-		public RuntimeTargetsFile(string targetsFilePath) => m_targetsFileTempPath = targetsFilePath;
+		public RuntimeTargetsFile(string targetsFileTempPath) => m_targetsFileTempPath = targetsFileTempPath;
 
-		public string GetBuildArg() => $"-p:DirectoryBuildTargetsPath={m_targetsFileTempPath}";
+		public string GetBuildArg() => $"-p:DirectoryBuildTargetsPath=\"{m_targetsFileTempPath}\"";
 
 		public void Dispose()
 		{

--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -62,9 +62,9 @@ public static class DotNetBuild
 
 				var extraProperties = settings.GetExtraPropertyArgs("clean");
 				if (msbuildSettings is null)
-					RunDotNet(new[] { "clean", solutionName, "-c", settings.GetConfiguration(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg() }.Concat(extraProperties));
+					RunDotNet(new[] { "clean", solutionName, "-c", settings.GetConfiguration(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetContinuousIntegrationBuildArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg() }.Concat(extraProperties));
 				else
-					MSBuild(new[] { solutionName, "-t:Clean", settings.GetConfigurationArg(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg() }.Concat(extraProperties));
+					MSBuild(new[] { solutionName, "-t:Clean", settings.GetConfigurationArg(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetContinuousIntegrationBuildArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg() }.Concat(extraProperties));
 			});
 
 		build.Target("restore")
@@ -74,9 +74,9 @@ public static class DotNetBuild
 				using var runtimeTargetsFile = RuntimeTargetsFile.Create();
 				var extraProperties = settings.GetExtraPropertyArgs("restore");
 				if (msbuildSettings is null)
-					RunDotNet(new[] { "restore", solutionName, settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
+					RunDotNet(new[] { "restore", solutionName, settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetContinuousIntegrationBuildArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
 				else
-					MSBuild(new[] { solutionName, "-t:Restore", settings.GetConfigurationArg(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
+					MSBuild(new[] { solutionName, "-t:Restore", settings.GetConfigurationArg(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetContinuousIntegrationBuildArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
 
 				if (DotNetLocalTool.Any())
 					RunDotNet("tool", "restore");
@@ -90,9 +90,9 @@ public static class DotNetBuild
 				using var runtimeTargetsFile = RuntimeTargetsFile.Create();
 				var extraProperties = settings.GetExtraPropertyArgs("build");
 				if (msbuildSettings is null)
-					RunDotNet(new[] { "build", solutionName, "-c", settings.GetConfiguration(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), "--no-restore", settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), settings.GetBuildSummaryArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
+					RunDotNet(new[] { "build", solutionName, "-c", settings.GetConfiguration(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetContinuousIntegrationBuildArg(), "--no-restore", settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), settings.GetBuildSummaryArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
 				else
-					MSBuild(new[] { solutionName, settings.GetConfigurationArg(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), settings.GetBuildSummaryArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
+					MSBuild(new[] { solutionName, settings.GetConfigurationArg(), settings.GetPlatformArg(), settings.GetBuildNumberArg(), settings.GetContinuousIntegrationBuildArg(), settings.GetVerbosityArg(), settings.GetMaxCpuCountArg(), settings.GetBuildSummaryArg(), runtimeTargetsFile.GetBuildArg() }.Concat(extraProperties));
 			});
 
 		build.Target("test")
@@ -181,6 +181,7 @@ public static class DotNetBuild
 						"-c", settings.GetConfiguration(),
 						settings.GetPlatformArg(),
 						settings.GetBuildNumberArg(),
+						settings.GetContinuousIntegrationBuildArg(),
 						"--no-build",
 						"--output", tempOutputPath,
 						versionSuffix is not null ? "--version-suffix" : null, versionSuffix,
@@ -196,6 +197,7 @@ public static class DotNetBuild
 						settings.GetConfigurationArg(),
 						settings.GetPlatformArg(),
 						settings.GetBuildNumberArg(),
+						settings.GetContinuousIntegrationBuildArg(),
 						"-p:NoBuild=true",
 						$"-p:PackageOutputPath={tempOutputPath}",
 						versionSuffix is not null ? $"-p:VersionSuffix={versionSuffix}" : null,
@@ -399,6 +401,7 @@ public static class DotNetBuild
 								"-c", settings.GetConfiguration(),
 								settings.GetPlatformArg(),
 								settings.GetBuildNumberArg(),
+								settings.GetContinuousIntegrationBuildArg(),
 								"--nologo",
 								"--verbosity", "quiet",
 								"--output", Path.Combine("tools", "bin", framework, "XmlDocGen"));
@@ -991,8 +994,6 @@ public static class DotNetBuild
 			foreach (var (key, value) in pairs)
 				yield return $"-p:{key}={value}";
 		}
-		if (settings.GetBuildNumber() is not null)
-			yield return "-p:ContinuousIntegrationBuild=true";
 	}
 
 	/// <summary>
@@ -1051,6 +1052,7 @@ public static class DotNetBuild
 					settings.GetConfiguration(),
 					settings.GetPlatformArg(),
 					settings.GetBuildNumberArg(),
+					settings.GetContinuousIntegrationBuildArg(),
 					"--no-build",
 					settings.GetVerbosityArg(),
 					settings.GetMaxCpuCountArg(),
@@ -1068,6 +1070,12 @@ public static class DotNetBuild
 	/// </summary>
 	[Obsolete("Use other overload.")]
 	public static IEnumerable<string> GetExtraPropertyArgs(string target, DotNetBuildSettings settings) => settings.GetExtraPropertyArgs(target);
+
+	/// <summary>
+	/// Gets the argument that enables CI Build settings.
+	/// </summary>
+	private static string? GetContinuousIntegrationBuildArg(this DotNetBuildSettings settings) =>
+		settings.GetBuildNumber() is not null ? "-p:ContinuousIntegrationBuild=true" : null;
 
 	private static DotNetPackageInfo GetPackageInfo(string path)
 	{

--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -1074,8 +1074,27 @@ public static class DotNetBuild
 	/// <summary>
 	/// Gets the argument that enables CI Build settings.
 	/// </summary>
-	private static string? GetContinuousIntegrationBuildArg(this DotNetBuildSettings settings) =>
-		settings.GetBuildNumber() is not null ? "-p:ContinuousIntegrationBuild=true" : null;
+	private static string? GetContinuousIntegrationBuildArg(this DotNetBuildSettings settings)
+	{
+		// check common CI environment variables; cf. https://github.com/watson/ci-info/blob/master/vendors.json
+		foreach (var name in new[]
+		{
+			"CI", // GitHub Actions, GitLab CI, Travis CI, CircleCI, and others
+			"GITHUB_ACTIONS", // GitHub Actions
+			"GITLAB_CI", // GitLab CI
+			"CIRCLECI", // CircleCI
+			"TRAVIS", // Travis CI
+			"APPVEYOR", // AppVeyor
+			"TF_BUILD", // Azure Pipelines
+			"BUILD_ID", // Jenkins
+		})
+		{
+			if (Environment.GetEnvironmentVariable(name) is not (null or "" or "false" or "False" or "FALSE"))
+				return "-p:ContinuousIntegrationBuild=true";
+		}
+
+		return null;
+	}
 
 	private static DotNetPackageInfo GetPackageInfo(string path)
 	{

--- a/src/Faithlife.Build/DotNetBuild.cs
+++ b/src/Faithlife.Build/DotNetBuild.cs
@@ -991,6 +991,8 @@ public static class DotNetBuild
 			foreach (var (key, value) in pairs)
 				yield return $"-p:{key}={value}";
 		}
+		if (settings.GetBuildNumber() is not null)
+			yield return "-p:ContinuousIntegrationBuild=true";
 	}
 
 	/// <summary>

--- a/src/Faithlife.Build/Faithlife.Build.csproj
+++ b/src/Faithlife.Build/Faithlife.Build.csproj
@@ -28,4 +28,8 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="Runtime.Directory.Build.targets" />
+  </ItemGroup>
+
 </Project>

--- a/src/Faithlife.Build/Runtime.Directory.Build.targets
+++ b/src/Faithlife.Build/Runtime.Directory.Build.targets
@@ -16,10 +16,12 @@
   </PropertyGroup>
 
   <!-- Enforce CI properties -->
-  <PropertyGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
+  <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder Condition=" '$(_FaithlifeBuildAllowedOutputExtensionsInPackageBuildOutputFolderContainsPdb)' != 'true' ">$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(BuildNumber)' != '' ">
     <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/Faithlife.Build/Runtime.Directory.Build.targets
+++ b/src/Faithlife.Build/Runtime.Directory.Build.targets
@@ -1,0 +1,37 @@
+<!-- NOTE: This file is not exposed via the NuGet package (which would require all projects
+  to take a dependency on Faithlife.Build) but is injected into the build at runtime. -->
+<Project>
+  <!-- Import the real Directory.Build.targets if it exists -->
+  <PropertyGroup>
+    <_FaithlifeBuildDirectoryBuildTargetsFile>Directory.Build.targets</_FaithlifeBuildDirectoryBuildTargetsFile>
+    <_FaithlifeBuildDirectoryBuildTargetsBasePath>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_FaithlifeBuildDirectoryBuildTargetsFile)'))</_FaithlifeBuildDirectoryBuildTargetsBasePath>
+    <_FaithlifeBuildOriginalDirectoryBuildTargetsPath>$([System.IO.Path]::Combine('$(_FaithlifeBuildDirectoryBuildTargetsBasePath)', '$(_FaithlifeBuildDirectoryBuildTargetsFile)'))</_FaithlifeBuildOriginalDirectoryBuildTargetsPath>
+  </PropertyGroup>
+  <Import Project="$(_FaithlifeBuildOriginalDirectoryBuildTargetsPath)" Condition="Exists('$(_FaithlifeBuildOriginalDirectoryBuildTargetsPath)')" />
+
+  <!-- Check if properties were already set -->
+  <PropertyGroup>
+    <_FaithlifeBuildAllowedOutputExtensionsInPackageBuildOutputFolderContainsPdb Condition=" $(AllowedOutputExtensionsInPackageBuildOutputFolder.Contains('.pdb')) ">true</_FaithlifeBuildAllowedOutputExtensionsInPackageBuildOutputFolderContainsPdb>
+    <_FaithlifeBuildPublishRepositoryUrlWasSet Condition="'$(PublishRepositoryUrl)' != ''">true</_FaithlifeBuildPublishRepositoryUrlWasSet>
+  </PropertyGroup>
+
+  <!-- Enforce CI properties -->
+  <PropertyGroup Condition=" '$(BuildNumber)' != '' ">
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <Target Name="FaithlifeBuildWarnings" BeforeTargets="BeforeBuild">
+    <Warning
+      Condition=" '$(_FaithlifeBuildPublishRepositoryUrlWasSet)' == 'true' "
+      Code="FLBLD0001"
+      Text="&lt;PublishRepositoryUrl> was set explicitly; this property should be omitted to use defaults from Faithlife.Build." />
+    <Warning
+      Condition=" '$(_FaithlifeBuildAllowedOutputExtensionsInPackageBuildOutputFolderContainsPdb)' == 'true' "
+      Code="FLBLD0002"
+      Text="&lt;AllowedOutputExtensionsInPackageBuildOutputFolder> is set explicitly; this property should be omitted to use defaults from Faithlife.Build." />
+  </Target>
+</Project>

--- a/src/Faithlife.Build/Runtime.Directory.Build.targets
+++ b/src/Faithlife.Build/Runtime.Directory.Build.targets
@@ -16,12 +16,11 @@
   </PropertyGroup>
 
   <!-- Enforce CI properties -->
-  <PropertyGroup Condition=" '$(BuildNumber)' != '' ">
+  <PropertyGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <Target Name="FaithlifeBuildWarnings" BeforeTargets="BeforeBuild">

--- a/src/Faithlife.Build/Runtime.Directory.Build.targets
+++ b/src/Faithlife.Build/Runtime.Directory.Build.targets
@@ -17,7 +17,7 @@
 
   <!-- Enforce CI properties -->
   <PropertyGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder Condition=" '$(_FaithlifeBuildAllowedOutputExtensionsInPackageBuildOutputFolderContainsPdb)' != 'true' ">$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>


### PR DESCRIPTION
Use `DirectoryBuildTargetsPath` as an extension mechanism to inject a custom `Directory.Build.targets` file that enforces the properties we want to be set for CI builds. Also issues warnings for the properties that can be detected to be set unnecessarily already.

We can now inject custom MSBuild logic at runtime without having to add a `buildTransitive` file to the Faithlife.Build NuGet package _and also_ make every project that we build add a reference (or `<GlobalPackageReference>`) to Faithlife.Build. (Probably to a separate, new NuGet package because we wouldn't actually want to make Faithlife.Build a dependency.)