### PR TITLE
Add PublishContainer method

### DIFF
--- a/src/Faithlife.Build/DotNetPublishContainerSettings.cs
+++ b/src/Faithlife.Build/DotNetPublishContainerSettings.cs
@@ -1,0 +1,31 @@
+namespace Faithlife.Build;
+
+/// <summary>
+/// Settings for publishing a .NET project to a Linux container.
+/// </summary>
+public sealed class DotNetPublishContainerSettings
+{
+	/// <summary>
+	/// The container image family, or <c>null</c> to use the SDK default value.
+	/// </summary>
+	/// <remarks>See <a href="https://learn.microsoft.com/en-us/dotnet/core/containers/publish-configuration#containerfamily">ContainerFamily</a>.</remarks>
+	public string? Family { get; set; }
+
+	/// <summary>
+	/// The tags to apply to the published container image.
+	/// </summary>
+	/// <remarks>See <a href="https://learn.microsoft.com/en-us/dotnet/core/containers/publish-configuration#containerimagetag">ContainerImageTags</a>.</remarks>
+	public IReadOnlyList<string>? ImageTags { get; set; }
+
+	/// <summary>
+	/// The destination registry to publish to, or <c>null</c> to publish to the local Docker daemon.
+	/// </summary>
+	/// <remarks>See <a href="https://learn.microsoft.com/en-us/dotnet/core/containers/publish-configuration#containerregistry">ContainerRegistry</a>.</remarks>
+	public string? Registry { get; set; }
+
+	/// <summary>
+	/// The container repository for the published image, or <c>null</c> to use the SDK default value.
+	/// </summary>
+	/// <remarks>See <a href="https://learn.microsoft.com/en-us/dotnet/core/containers/publish-configuration#containerrepository">ContainerRepository</a>.</remarks>
+	public string? Repository { get; set; }
+}


### PR DESCRIPTION
This publishes a single project as an x64 Linux Docker container, using all Faithlife.Build's standard build settings.

Some settings (e.g., architecture) are hard-coded by Faithlife.Build while others in `DotNetPublishContainerSettings` can be customized by the caller to choose a non-default base image, registry, etc.